### PR TITLE
fix: support SSE/HTTP transport and add Bearer token authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ VELOCIRAPTOR_TIMEOUT=30
 # MCP Server Configuration
 MCP_SERVER_HOST=127.0.0.1
 MCP_SERVER_PORT=8000
+# MCP_API_KEY=your-secret-api-key-here
 
 # Logging Configuration
 LOG_LEVEL=INFO

--- a/velociraptor_mcp_server/__main__.py
+++ b/velociraptor_mcp_server/__main__.py
@@ -48,6 +48,12 @@ def create_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Disable SSL certificate verification",
     )
+    parser.add_argument(
+        "--transport",
+        choices=["sse", "stdio", "streamable-http"],
+        default="sse",
+        help="Transport mode: sse (HTTP, default), stdio (stdin/stdout), or streamable-http",
+    )
     parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
 
     return parser
@@ -78,7 +84,7 @@ def main() -> None:
 
         # Create and start server
         server = create_server(config)
-        server.start()
+        server.start(transport=args.transport)
 
     except KeyboardInterrupt:
         logger.info("Server stopped by user")

--- a/velociraptor_mcp_server/__main__.py
+++ b/velociraptor_mcp_server/__main__.py
@@ -49,6 +49,10 @@ def create_parser() -> argparse.ArgumentParser:
         help="Disable SSL certificate verification",
     )
     parser.add_argument(
+        "--api-key",
+        help="API key for Bearer token authentication (overrides MCP_API_KEY env var)",
+    )
+    parser.add_argument(
         "--transport",
         choices=["sse", "stdio", "streamable-http"],
         default="sse",
@@ -76,6 +80,8 @@ def main() -> None:
     config.server.host = args.host
     config.server.port = args.port
     config.server.log_level = args.log_level
+    if args.api_key:
+        config.server.api_key = args.api_key
 
     try:
         # Validate configuration

--- a/velociraptor_mcp_server/config.py
+++ b/velociraptor_mcp_server/config.py
@@ -5,7 +5,7 @@ Configuration management for Velociraptor MCP Server.
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass
@@ -46,6 +46,7 @@ class ServerConfig:
     disabled_tools: List[str] = field(default_factory=list)
     disabled_categories: List[str] = field(default_factory=list)
     read_only: bool = False
+    api_key: Optional[str] = None
 
     @classmethod
     def from_env(cls) -> "ServerConfig":
@@ -65,6 +66,7 @@ class ServerConfig:
             disabled_tools=disabled_tools,
             disabled_categories=disabled_categories,
             read_only=os.getenv("VELOCIRAPTOR_READ_ONLY", "false").lower() in {"1", "true", "yes"},
+            api_key=os.getenv("MCP_API_KEY"),
         )
 
 

--- a/velociraptor_mcp_server/server.py
+++ b/velociraptor_mcp_server/server.py
@@ -880,13 +880,23 @@ class VelociraptorMCPServer:
             # Fallback to empty model
             return model_class()
 
-    def start(self, host: str = None, port: int = None) -> None:
-        """Start the MCP server using stdio transport."""
-        logger.info("Starting Velociraptor MCP Server (stdio transport)")
+    def start(self, transport: str = "sse") -> None:
+        """Start the MCP server.
+
+        Args:
+            transport: Transport mode - 'sse' (HTTP), 'stdio' (stdin/stdout),
+                       or 'streamable-http'.
+        """
+        host = self.config.server.host
+        port = self.config.server.port
+        logger.info("Starting Velociraptor MCP Server (%s transport)", transport)
         logger.info("SSL Verify: %s", self.config.velociraptor.ssl_verify)
 
-        # stdio transport is required when the server is invoked via MCP command in .mcp.json
-        self.app.run()
+        if transport == "stdio":
+            self.app.run(transport="stdio")
+        else:
+            logger.info("Listening on %s:%s", host, port)
+            self.app.run(transport=transport, host=host, port=port)
 
     async def close(self) -> None:
         """Close the server and cleanup resources."""

--- a/velociraptor_mcp_server/server.py
+++ b/velociraptor_mcp_server/server.py
@@ -8,6 +8,7 @@ import logging
 from typing import Optional
 
 from fastmcp import FastMCP
+from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
 from pydantic import BaseModel, Field
 
 from .client import VelociraptorClient
@@ -98,6 +99,40 @@ class CollectArtifactDetailsArgs(BaseModel):
     )
 
 
+class BearerAuthMiddleware(Middleware):
+    """Middleware that enforces Bearer token authentication on all MCP requests."""
+
+    def __init__(self, api_key: str) -> None:
+        self.api_key = api_key
+
+    async def on_request(self, context: MiddlewareContext, call_next: CallNext):
+        """Validate the Bearer token on every incoming request."""
+        auth_header = None
+
+        # Try FastMCP's built-in HTTP header helper (available in SSE/HTTP transport)
+        try:
+            from fastmcp.server.dependencies import get_http_headers
+            headers = get_http_headers()
+            auth_header = headers.get("authorization") or headers.get("Authorization")
+        except (RuntimeError, ImportError):
+            pass
+
+        if not auth_header:
+            raise ValueError("Authorization header required. Use: Authorization: Bearer <api-key>")
+
+        # Extract token from "Bearer <token>" format
+        token = None
+        if auth_header.lower().startswith("bearer "):
+            token = auth_header[7:]
+        else:
+            token = auth_header
+
+        if token != self.api_key:
+            raise ValueError("Invalid API key")
+
+        return await call_next(context)
+
+
 class VelociraptorMCPServer:
     """Main MCP server for Velociraptor integration."""
 
@@ -105,6 +140,11 @@ class VelociraptorMCPServer:
         self.config = config
         self._client: Optional[VelociraptorClient] = None
         self.app = FastMCP(name="Velociraptor MCP Server", version="0.1.0")
+
+        # Register auth middleware if API key is configured
+        if config.server.api_key:
+            self.app.add_middleware(BearerAuthMiddleware(config.server.api_key))
+            logger.info("Bearer token authentication enabled")
 
         # Register tools
         self._register_tools()

--- a/velociraptor_mcp_server/server.py
+++ b/velociraptor_mcp_server/server.py
@@ -7,8 +7,9 @@ import json
 import logging
 from typing import Optional
 
+import hmac
+
 from fastmcp import FastMCP
-from fastmcp.server.middleware import Middleware, MiddlewareContext, CallNext
 from pydantic import BaseModel, Field
 
 from .client import VelociraptorClient
@@ -99,38 +100,41 @@ class CollectArtifactDetailsArgs(BaseModel):
     )
 
 
-class BearerAuthMiddleware(Middleware):
-    """Middleware that enforces Bearer token authentication on all MCP requests."""
+class BearerAuthASGIMiddleware:
+    """Pure ASGI middleware that enforces Bearer token authentication at the HTTP layer.
 
-    def __init__(self, api_key: str) -> None:
+    Unlike FastMCP's protocol-level middleware, this intercepts requests before
+    they reach the MCP transport, ensuring HTTP headers are always accessible.
+    """
+
+    def __init__(self, app, api_key: str) -> None:
+        self.app = app
         self.api_key = api_key
 
-    async def on_request(self, context: MiddlewareContext, call_next: CallNext):
-        """Validate the Bearer token on every incoming request."""
-        auth_header = None
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            # Extract Authorization header from ASGI scope
+            headers = dict(scope.get("headers", []))
+            auth_value = headers.get(b"authorization", b"").decode("latin-1")
 
-        # Try FastMCP's built-in HTTP header helper (available in SSE/HTTP transport)
-        try:
-            from fastmcp.server.dependencies import get_http_headers
-            headers = get_http_headers()
-            auth_header = headers.get("authorization") or headers.get("Authorization")
-        except (RuntimeError, ImportError):
-            pass
+            token = auth_value[7:] if auth_value.lower().startswith("bearer ") else auth_value
 
-        if not auth_header:
-            raise ValueError("Authorization header required. Use: Authorization: Bearer <api-key>")
+            if not token or not hmac.compare_digest(token, self.api_key):
+                await send({
+                    "type": "http.response.start",
+                    "status": 401,
+                    "headers": [
+                        (b"content-type", b"text/plain; charset=utf-8"),
+                        (b"www-authenticate", b"Bearer"),
+                    ],
+                })
+                await send({
+                    "type": "http.response.body",
+                    "body": b"Unauthorized: invalid or missing Bearer token",
+                })
+                return
 
-        # Extract token from "Bearer <token>" format
-        token = None
-        if auth_header.lower().startswith("bearer "):
-            token = auth_header[7:]
-        else:
-            token = auth_header
-
-        if token != self.api_key:
-            raise ValueError("Invalid API key")
-
-        return await call_next(context)
+        await self.app(scope, receive, send)
 
 
 class VelociraptorMCPServer:
@@ -140,11 +144,6 @@ class VelociraptorMCPServer:
         self.config = config
         self._client: Optional[VelociraptorClient] = None
         self.app = FastMCP(name="Velociraptor MCP Server", version="0.1.0")
-
-        # Register auth middleware if API key is configured
-        if config.server.api_key:
-            self.app.add_middleware(BearerAuthMiddleware(config.server.api_key))
-            logger.info("Bearer token authentication enabled")
 
         # Register tools
         self._register_tools()
@@ -934,6 +933,12 @@ class VelociraptorMCPServer:
 
         if transport == "stdio":
             self.app.run(transport="stdio")
+        elif self.config.server.api_key:
+            logger.info("Listening on %s:%s (Bearer auth enabled)", host, port)
+            import uvicorn
+            asgi_app = self.app.http_app(transport=transport)
+            asgi_app = BearerAuthASGIMiddleware(asgi_app, self.config.server.api_key)
+            uvicorn.run(asgi_app, host=host, port=port)
         else:
             logger.info("Listening on %s:%s", host, port)
             self.app.run(transport=transport, host=host, port=port)


### PR DESCRIPTION
## Summary

Two issues addressed:

1. **`--host` / `--port` are silently ignored** — `server.start()` hardcodes stdio transport via `self.app.run()`, so the server blocks on stdin instead of listening on a TCP port.
2. **No authentication** — once exposed over HTTP, anyone who can reach the port can use all MCP tools (including artifact collection and VQL queries).

## Changes

### Transport fix

| File | What changed |
|---|---|
| `__main__.py` | Added `--transport` argument (`sse` / `stdio` / `streamable-http`, default `sse`) |
| `server.py` | Rewrote `start()` to dispatch on transport — SSE/streamable-http bind to host:port, stdio preserved |

### Bearer token authentication

| File | What changed |
|---|---|
| `server.py` | Added `BearerAuthMiddleware` using FastMCP's middleware system; registered when API key is set |
| `config.py` | Added `api_key: Optional[str]` to `ServerConfig`, reads `MCP_API_KEY` env var |
| `__main__.py` | Added `--api-key` CLI flag (overrides env var) |
| `.env.example` | Documented `MCP_API_KEY` |

## Usage

```bash
# SSE mode with authentication
velociraptor-mcp-server --host 0.0.0.0 --port 8001 \
  --api-key my-secret-key \
  --api-config ./api.config.yaml

# Clients must include the header:
# Authorization: Bearer my-secret-key

# Or via environment variable
export MCP_API_KEY=my-secret-key
velociraptor-mcp-server --host 0.0.0.0 --port 8001

# stdio mode (no auth needed — local process communication)
velociraptor-mcp-server --transport stdio --api-config ./api.config.yaml
```

## Backward Compatibility

- Default transport changed from `stdio` → `sse` to match README examples (`http://127.0.0.1:8000/sse/`). Users relying on stdio need to add `--transport stdio`.
- Authentication is **opt-in** — no API key = no auth check (existing behavior preserved).